### PR TITLE
Update build.yml to check for runtime crashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,11 @@ on:
 
 jobs:
   build:
-    name: Build and simulate
+    name: Build and replay match
     runs-on: ubuntu-latest
     container: wpilib/roborio-cross-ubuntu:2024-22.04
+    env:
+      AKIT_LOG_PATH: https://github.com/AEMBOT/FRC_2024/tree/main/.github/workflows/Log_24-10-06_16-39-52_e3.wpilog
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container: wpilib/roborio-cross-ubuntu:2024-22.04
     env:
-      AKIT_LOG_PATH: https://github.com/AEMBOT/FRC_2024/tree/main/.github/workflows/Log_24-10-06_16-39-52_e3.wpilog
+      AKIT_LOG_PATH: .github/workflows/Log_24-10-06_16-39-52_e3.wpilog
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,21 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build and simulate
     runs-on: ubuntu-latest
     container: wpilib/roborio-cross-ubuntu:2024-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Grant execute permission
         run: chmod +x gradlew
       - name: Build robot code
         run: ./gradlew build
+
+      # Runs a simulation to spot check crashes
+      - name: Run simulation to check for runtime errors
+        run: timeout 1m ./gradlew simulateJava 2>&1 | awk -v rc=0 '/The robot program quit unexpectedly/ { rc=1 } 1; END {exit rc}'
+          # 1. Run simulation with 1 minute timeout
+          # 2. Redirect stderr to stdout (just in case)
+          # 3. Use awk to check for robot crash message and set the return code based on this. (Alternative to grep that doesn't filter the simulation output)
+          # Stolen from 1540 Flaming Chickens and https://github.com/AusTINCANsProgrammingTeam/2022RobotCode/blob/041e469ab0d2047a0c6d66b3d953b5adc3b3e29a/.github/workflows/main.yml#L35-L41


### PR DESCRIPTION
Start the simulator and, because we are defaulting to REPLAY mode, use an existing AdvantageKit log from a match.

NOTE: Does not do any "real" checks (like motor velocities or communication), but it is better than nothing.